### PR TITLE
Fix up the DAB RBAC data migration so it will run

### DIFF
--- a/galaxy_ng/app/migrations/0055_galaxy_role_defs_to_dab_defs.py
+++ b/galaxy_ng/app/migrations/0055_galaxy_role_defs_to_dab_defs.py
@@ -1,25 +1,34 @@
 from django.db import migrations
 
+from awx.main.migrations._dab_rbac import migrate_to_new_rbac, create_permissions_as_operation, setup_managed_role_definitions
+
 
 def copy_permissions_to_role_definitions(apps, schema_editor):
     Permission = apps.get_model('auth', 'Permission')
-    RoleDefinition = apps.get_model('ansible_base.rbac', 'RoleDefinition')
+    RoleDefinition = apps.get_model('dab_rbac', 'RoleDefinition')
 
+    # TODO: migrate from pulp role model or something like that
     permissions = Permission.objects.all().filter(name__icontains='namespace')
-    for perm in permissions:
-        RoleDefinition.objects.create(
-            name=perm.name,
-            permissions=[perm.codename],
-            content_type=perm.content_type
+    rd = RoleDefinition.objects.get_or_create(
+        name='Namespace Admin',
+        defaults=dict(
+            content_type=permissions[0].content_type,
+            managed=True
         )
+    )
+    for perm in permissions:
+        rd.permissions.add(perm)
+
 
 
 class Migration(migrations.Migration):
 
     dependencies = [
         ('galaxy', '0054_dab_resource_views'),
+        ('dab_rbac', '__first__'),
     ]
 
     operations = [
-        # migrations.RunPython(copy_permissions_to_role_definitions),
+        migrations.RunPython(create_permissions_as_operation, migrations.RunPython.noop),
+        migrations.RunPython(copy_permissions_to_role_definitions),
     ]

--- a/galaxy_ng/app/migrations/0055_galaxy_role_defs_to_dab_defs.py
+++ b/galaxy_ng/app/migrations/0055_galaxy_role_defs_to_dab_defs.py
@@ -1,8 +1,12 @@
+import logging
+
 from django.db import migrations
 
 from django.apps import apps as global_apps
 
 from ansible_base.rbac.management import create_dab_permissions
+
+logger = logging.getLogger(__name__)
 
 
 def create_permissions_as_operation(apps, schema_editor):
@@ -10,21 +14,22 @@ def create_permissions_as_operation(apps, schema_editor):
 
 
 def copy_permissions_to_role_definitions(apps, schema_editor):
-    Permission = apps.get_model('auth', 'Permission')
+    Permission = apps.get_model('dab_rbac', 'DABPermission')
     RoleDefinition = apps.get_model('dab_rbac', 'RoleDefinition')
 
     # TODO: migrate from pulp role model or something like that
     permissions = Permission.objects.all().filter(name__icontains='namespace')
-    rd = RoleDefinition.objects.get_or_create(
+    rd, created = RoleDefinition.objects.get_or_create(
         name='Namespace Admin',
         defaults=dict(
             content_type=permissions[0].content_type,
             managed=True
         )
     )
-    for perm in permissions:
-        rd.permissions.add(perm)
-
+    if created:
+        logger.info(f'Created RoleDefinition {rd.name}')
+        for perm in permissions:
+            rd.permissions.add(perm)
 
 
 class Migration(migrations.Migration):

--- a/galaxy_ng/app/migrations/0055_galaxy_role_defs_to_dab_defs.py
+++ b/galaxy_ng/app/migrations/0055_galaxy_role_defs_to_dab_defs.py
@@ -1,6 +1,12 @@
 from django.db import migrations
 
-from awx.main.migrations._dab_rbac import migrate_to_new_rbac, create_permissions_as_operation, setup_managed_role_definitions
+from django.apps import apps as global_apps
+
+from ansible_base.rbac.management import create_dab_permissions
+
+
+def create_permissions_as_operation(apps, schema_editor):
+    create_dab_permissions(global_apps.get_app_config("galaxy"), apps=apps)
 
 
 def copy_permissions_to_role_definitions(apps, schema_editor):


### PR DESCRIPTION
got migrations finishing with this and verifying

```
pulp_1          |   Applying galaxy.0054_dab_resource_views... OK
pulp_1          |   Applying galaxy.0055_galaxy_role_defs_to_dab_defs...pulp [None]: galaxy_ng.app.migrations.0055_galaxy_role_defs_to_dab_defs:INFO: Created RoleDefinition Namespace Admin
pulp_1          | Adding content type 'galaxy | legacyroledownloadcount'
pulp_1          | Adding content type 'galaxy | legacyroletag'
```

Basically took what AWX did