### PR TITLE
Add summary_fields to galaxy and pulp models

### DIFF
--- a/galaxy_ng/app/__init__.py
+++ b/galaxy_ng/app/__init__.py
@@ -22,3 +22,60 @@ class PulpGalaxyPluginAppConfig(PulpPluginAppConfig):
             Task,
             parent_field_name=None
         )
+
+        add_dab_summary_fields_to_models()
+
+
+def add_dab_summary_fields_to_models():
+    """DAB Expects Content Types to expose summary_fields method.
+
+    Apps must be ready to start importing and patching models.
+    """
+    from ansible_base.lib.utils.models import user_summary_fields
+    from pulp_ansible.app import models as pulp_ansible_models
+    from pulp_container.app import models as pulp_container_models
+    from pulpcore.plugin import models as pulpcore_models
+
+    from galaxy_ng.app.models import collectionimport as galaxy_collectionimport_models
+    from galaxy_ng.app.models import container as galaxy_container_models
+    from galaxy_ng.app.models import namespace as galaxy_namespace_models
+    from galaxy_ng.app.models.auth import User
+
+    User.add_to_class('summary_fields', user_summary_fields)
+
+    common_summary_fields = ("pk", "name")
+    summary_fields_serializers = {
+        pulpcore_models.Task: common_summary_fields,
+        pulp_ansible_models.AnsibleDistribution: common_summary_fields,
+        pulp_ansible_models.AnsibleCollectionDeprecated: common_summary_fields,
+        pulp_ansible_models.AnsibleNamespaceMetadata: common_summary_fields,
+        pulp_ansible_models.Tag: common_summary_fields,
+        pulp_ansible_models.AnsibleNamespace: common_summary_fields,
+        pulp_ansible_models.CollectionVersionSignature: ("pk", "pubkey_fingerprint"),
+        pulp_ansible_models.CollectionVersion: common_summary_fields + ("version",),
+        pulp_ansible_models.Collection: common_summary_fields + ("namespace",),
+        pulp_ansible_models.CollectionRemote: common_summary_fields,
+        pulp_ansible_models.AnsibleRepository: common_summary_fields,
+        galaxy_collectionimport_models.CollectionImport: common_summary_fields + ("version",),
+        galaxy_namespace_models.NamespaceLink: common_summary_fields,
+        galaxy_namespace_models.Namespace: common_summary_fields,
+        galaxy_container_models.ContainerDistroReadme: ("pk",),
+        galaxy_container_models.ContainerNamespace: common_summary_fields,
+        galaxy_container_models.ContainerRegistryRemote: common_summary_fields,
+        galaxy_container_models.ContainerRegistryRepos: ("pk",),
+        pulp_container_models.ContainerDistribution: common_summary_fields,
+        pulp_container_models.ContainerNamespace: common_summary_fields,
+        pulp_container_models.ContainerRepository: common_summary_fields,
+    }
+
+    def add_summary_fields(obj):
+        return {
+            "id" if field == "pk" else field: getattr(obj, field)
+            for field in summary_fields_serializers[obj.__class__]
+        }
+
+    for model_class in summary_fields_serializers:
+        if getattr(model_class, "summary_fields", None) is not None:
+            # Skip if model already defines a summary_fields method
+            continue
+        model_class.add_to_class("summary_fields", add_summary_fields)

--- a/galaxy_ng/tests/integration/dab/test_dab_rbac_contract.py
+++ b/galaxy_ng/tests/integration/dab/test_dab_rbac_contract.py
@@ -182,6 +182,14 @@ def assert_assignments(gc, user, namespace, expected=0):
     )
     assert r["count"] == expected
 
+    # Ensure summary_fields is populated with expected sub keys
+    summary_fields = r["results"][0]["summary_fields"]
+    expected_fields = {"created_by", "role_definition", "user", "content_objet"}
+    assert expected_fields.issubset(summary_fields)
+    # assert each entry has at least the id field
+    for field in expected_fields:
+        assert "id" in summary_fields[field]
+
 
 @pytest.mark.parametrize("by_api", ["dab", "pulp"])
 def test_give_custom_role_object(


### PR DESCRIPTION
Patch all the models to include `summary_fields` method.


3332
No-Issue

