### PR TITLE
Allow some pulp role APIs to function by first-assignment rule

### DIFF
--- a/galaxy_ng/app/dynaconf_hooks.py
+++ b/galaxy_ng/app/dynaconf_hooks.py
@@ -736,7 +736,7 @@ def configure_dynamic_settings(settings: Dynaconf) -> Dict[str, Any]:
 
 def configure_dab_required_settings(settings: Dynaconf) -> Dict[str, Any]:
     dab_settings = get_dab_settings(
-        installed_apps=settings.INSTALLED_APPS,
+        installed_apps=settings.INSTALLED_APPS + ['ansible_base.jwt_consumer'],
         rest_framework=settings.REST_FRAMEWORK,
         spectacular_settings=settings.SPECTACULAR_SETTINGS,
         authentication_backends=settings.AUTHENTICATION_BACKENDS,

--- a/galaxy_ng/tests/integration/dab/test_dab_rbac_contract.py
+++ b/galaxy_ng/tests/integration/dab/test_dab_rbac_contract.py
@@ -1,7 +1,5 @@
 import pytest
-
 from galaxykit.utils import GalaxyClientError
-
 
 # This tests the basic DAB RBAC contract using custom roles to do things
 


### PR DESCRIPTION
https://issues.redhat.com/browse/AAH-3354

I've thought about it, and I believe this is the best I can do.

This enables an API flow that always used to work, so we "make" it work along with the new models.
 - Make a role in the old API
 - give a user that role to and object

This was giving 400 errors, because the DAB RBAC validators did not like that. So this adds a rule where if it is the _first_ assignment for that role, it can go "yoink" and change the RoleDefinition content_type to be what it needs to be to pass validation.

Don't merge until I take this out of draft, there's some fairly minimal validation-y TODOs.