### PR TITLE
Add logging to see exactly what is happening in test failures

### DIFF
--- a/galaxy_ng/app/signals/handlers.py
+++ b/galaxy_ng/app/signals/handlers.py
@@ -6,6 +6,7 @@ galaxy_ng.app.__init__:PulpGalaxyPluginAppConfig.ready() method.
 
 import threading
 import contextlib
+import logging
 
 from django.dispatch import receiver
 from django.db.models.signals import post_save
@@ -39,6 +40,9 @@ from ansible_base.rbac import permission_registry
 from pulpcore.plugin.util import assign_role
 from pulpcore.plugin.util import remove_role
 from pulpcore.plugin.models.role import GroupRole, UserRole, Role
+
+
+logger = logging.getLogger(__name__)
 
 
 @receiver(post_save, sender=AnsibleRepository)
@@ -307,10 +311,13 @@ def lazy_content_type_correction(rd, obj):
         try:
             # If permissions will not pass the validator, then we do not want to do this
             validate_permissions_for_model(list(rd.permissions.all()), ct)
-        except ValidationError:
+        except ValidationError as exc:
+            logger.warning(f'Assignment to {rd.name} for {type(obj)} violates a DAB role validation rule: {str(exc)}')
             return
         rd.content_type = ct
         rd.save(update_fields=['content_type'])
+    else:
+        logger.warning(f'Assignment to {rd.name} for {type(obj)} mis-matches with existing assignments')
 
 
 @receiver(post_save, sender=UserRole)

--- a/galaxy_ng/app/signals/handlers.py
+++ b/galaxy_ng/app/signals/handlers.py
@@ -306,6 +306,8 @@ def lazy_content_type_correction(rd, obj):
 
     if rd.name in settings.ANSIBLE_BASE_JWT_MANAGED_ROLES:
         return
+    if ((obj is None) and (rd.content_type_id is None)) or (rd.content_type_id and obj._meta.model_name == rd.content_type.model):
+        return  # type already matches with intent, so nothing to do here, do not even log
     if not rd.user_assignments.exists():
         ct = ContentType.objects.get_for_model(obj)
         try:

--- a/galaxy_ng/tests/integration/dab/test_dab_rbac_contract.py
+++ b/galaxy_ng/tests/integration/dab/test_dab_rbac_contract.py
@@ -462,14 +462,14 @@ def test_give_user_custom_role_object(
     assert_object_role_assignments(gc, user, namespace, 0)
 
 
-def test_object_role_permission_validation(galaxy_client, custom_role_creator, namespace):
+def test_object_role_permission_validation(galaxy_client, custom_role_factory, namespace):
     gc = galaxy_client("admin")
 
     data = NS_FIXTURE_DATA.copy()
     data["name"] = "galaxy.namespace_custom_pulp_object_role"
     # Add a permission not valid for namespaces
     data["permissions"] += ["core.view_task"]
-    custom_obj_role_pulp = custom_role_creator(data, url_base=PULP_ROLE_URL)
+    custom_obj_role_pulp = custom_role_factory(data, url_base=PULP_ROLE_URL)
 
     user_r = gc.get("_ui/v2/users/")
     assert user_r["count"] > 0
@@ -536,7 +536,7 @@ def user_and_group(request, galaxy_client):
     return (user, group)
 
 
-def test_group_sync_from_pulp_to_dab(galaxy_client, assert_user_in_group, user_and_group, pulp_api):
+def test_group_sync_from_pulp_to_dab(galaxy_client, assert_user_in_group, user_and_group):
     gc = galaxy_client("admin")
     user, group = user_and_group
 


### PR DESCRIPTION
Trying to get more info from the "community" check which has tracebacks, but we need to know what happened before the traceback.