### PR TITLE
[alternative] Allow roles with no view permission

### DIFF
--- a/galaxy_ng/app/settings.py
+++ b/galaxy_ng/app/settings.py
@@ -419,6 +419,9 @@ ANSIBLE_BASE_ALLOW_SINGLETON_USER_ROLES = True
 ANSIBLE_BASE_ALLOW_SINGLETON_TEAM_ROLES = True
 # Pass ignore_conflicts=False for bulk_create calls for role evaluations
 ANSIBLE_BASE_EVALUATIONS_IGNORE_CONFLICTS = False
+# Allow creating roles with no view permission (even when model has a view permission)
+# because some tests or something made pulp roles that did this
+ANSIBLE_BASE_ROLES_REQUIRE_VIEW = False
 # Set up managed role definitions
 ANSIBLE_BASE_MANAGED_ROLE_REGISTRY = {
     'platform_auditor': {'name': 'Platform Auditor', 'shortname': 'sys_auditor'},


### PR DESCRIPTION
This is an alternative to https://github.com/jctanner/galaxy_ng/pull/16

I would prefer the other approach, but if this gets checks closer to passing, then I would understand choosing this instead of expediency. Out of the two, this is should make errors less likely, by making the validation less strict.